### PR TITLE
feat: update pl version supports

### DIFF
--- a/donut/model.py
+++ b/donut/model.py
@@ -69,6 +69,7 @@ class SwinEncoder(nn.Module):
             num_heads=[4, 8, 16, 32],
             num_classes=0,
         )
+        self.model.norm = None
 
         # weight init with swin
         if not name_or_path:

--- a/train.py
+++ b/train.py
@@ -51,8 +51,34 @@ def save_config_file(config, path):
         print(f"Config is saved at {save_path}")
 
 
+class ProgressBar(pl.callbacks.TQDMProgressBar):
+    def __init__(self, config):
+        super().__init__()
+        self.enable = True
+        self.config = config
+
+    def disable(self):
+        self.enable = False
+
+    def get_metrics(self, trainer, model):
+        items = super().get_metrics(trainer, model)
+        items.pop("v_num", None)
+        items["exp_name"] = f"{self.config.get('exp_name', '')}"
+        items["exp_version"] = f"{self.config.get('exp_version', '')}"
+        return items
+
+
+def set_seed(seed):
+    pytorch_lightning_version = int(pl.__version__[0])
+    if pytorch_lightning_version < 2:
+        pl.utilities.seed.seed_everything(seed, workers=True)
+    else:
+        import lightning_fabric
+        lightning_fabric.utilities.seed.seed_everything(seed, workers=True)
+
+
 def train(config):
-    pl.utilities.seed.seed_everything(config.get("seed", 42), workers=True)
+    set_seed(config.get("seed", 42))
 
     model_module = DonutModelPLModule(config)
     data_module = DonutDataPLModule(config)
@@ -111,11 +137,12 @@ def train(config):
         mode="min",
     )
 
+    bar = ProgressBar(config)
+
     custom_ckpt = CustomCheckpointIO()
     trainer = pl.Trainer(
-        resume_from_checkpoint=config.get("resume_from_checkpoint_path", None),
         num_nodes=config.get("num_nodes", 1),
-        gpus=torch.cuda.device_count(),
+        devices=torch.cuda.device_count(),
         strategy="ddp",
         accelerator="gpu",
         plugins=custom_ckpt,
@@ -127,10 +154,10 @@ def train(config):
         precision=16,
         num_sanity_val_steps=0,
         logger=logger,
-        callbacks=[lr_callback, checkpoint_callback],
+        callbacks=[lr_callback, checkpoint_callback, bar],
     )
 
-    trainer.fit(model_module, data_module)
+    trainer.fit(model_module, data_module, ckpt_path=config.get("resume_from_checkpoint_path", None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?

Update for compatibility with pytorch-lightning 2.0.3 as well as backward compatibility with previous version (>1.6.4)

Changes:

- add `on_validation_epoch_end()` and remove `validation_epoch_end()` in `LightningModule`
- `set_seed()` in `train()`
- add `TQDMProgressBar` in `callbacks` argument in `Trainer()`, and remove `get_progress_bar_dict()` in `LightningModule`
- add `ckpt_path` argument in `Trainer.fit()`, and remove `resume_from_checkpoint` argument in `Trainer()`

Minor changes:
- remove `self.model.norm` in `SwinEncoder` to free the unused parameters
- add `self.validation_step_outputs` variable in `LightningModule` for `on_validation_epoch_end()`
- change the `gpus` argument to `devices` argument in `Trainer()`