### PR TITLE
Pin timm version in package requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "transformers>=4.11.3",
-        "timm",
+        "timm==0.5.4",
         "datasets[vision]",
         "pytorch-lightning>=1.6.4",
         "nltk",


### PR DESCRIPTION
For me, fixing the timm version seems to suffice to fix #242 locally.

Other than that I kept the packages that are installed by `pip install`; for the package versions mentioned in https://github.com/clovaai/donut/#software-installation this means
```
torch                     2.0.1
torchvision               0.15.2
pytorch-lightning         2.0.9
transformers              4.33.2
```

Notice that I only tested the cpu version and the demo in `app.py`, but did not attempt any training.